### PR TITLE
bump Visual D version to 0.3.40

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -39,7 +39,7 @@
 ; Routinely Update
 ; ----------------
 ; Visual D
-!define VersionVisualD "0.3.38-1"
+!define VersionVisualD "0.3.40"
 
 ; DMC
 !define VersionDMC "857"


### PR DESCRIPTION
Update link to latest version. 

There might be another version (mostly to update the parser to adjust to new D syntax), but I don't know if it will be ready before the dmd release.