### PR TITLE
Windows installer: Warn before nuking the entire D installation

### DIFF
--- a/windows/d1-installer.nsi
+++ b/windows/d1-installer.nsi
@@ -266,8 +266,15 @@ Section "Uninstall"
 
   ; Remove shortcuts
   Delete "$SMPROGRAMS\D\D1 HTML Documentation.lnk"
-  RMDir /r /REBOOTOK "$SMPROGRAMS\D"
+  Delete "$SMPROGRAMS\D\D1 Command Prompt.lnk"
+  RMDir /REBOOTOK "$SMPROGRAMS\D"
 
+  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+  "The uninstaller will now recursively delete ALL files and directories under '$INSTDIR\dmd'. Continue?" \
+  IDOK rmdir
+  Abort
+
+  rmdir:
   ; Remove used directories
   RMDir /r /REBOOTOK "$INSTDIR\dmd"
   RMDir /REBOOTOK "$INSTDIR"

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -453,8 +453,16 @@ Section "Uninstall"
   ; Remove shortcuts
   Delete "$SMPROGRAMS\D\D2 HTML Documentation.lnk"
   Delete "$SMPROGRAMS\D\D2 Documentation.lnk"
-  RMDir /r "$SMPROGRAMS\D"
+  Delete "$SMPROGRAMS\D\D2 32-bit Command Prompt.lnk"
+  Delete "$SMPROGRAMS\D\D2 64-bit Command Prompt.lnk"
+  RMDir "$SMPROGRAMS\D"
 
+  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+  "The uninstaller will now recursively delete ALL files and directories under '$INSTDIR\dmd2'. Continue?" \
+  IDOK rmdir
+  Abort
+
+  rmdir:
   ; Remove used directories
   RMDir /r "$INSTDIR\dmd2"
   RMDir "$INSTDIR"


### PR DESCRIPTION
Currently, the uninstaller will nuke the entire D installation directory, including any potential user files or files edited by the user.

Ideally we should only delete the files that we have installed, if they have not been modified.

For now, at least, warn users that we are going to delete everything.