### PR TITLE
Fix issue 13234: when updating, uninstaller reports wrong installation directory

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -377,38 +377,6 @@ Function DetectVSAndSDK
     ClearErrors
 FunctionEnd
 
-; Get path component of file name
- ; Usage:
- ;   Push "C:\Program Files\Directory\Whatever"
- ;   Call GetPath
- ;   Pop $R0
-Function GetPath
- 
-  Exch $R0
-  Push $R1
-  Push $R2
-  Push $R3
- 
-  StrCpy $R1 0
-  StrLen $R2 $R0
- 
-  loop:
-    IntOp $R1 $R1 + 1
-    IntCmp $R1 $R2 get 0 get
-    StrCpy $R3 $R0 1 -$R1
-    StrCmp $R3 "\" get
-  Goto loop
- 
-  get:
-    StrCpy $R0 $R0 -$R1
- 
-    Pop $R3
-    Pop $R2
-    Pop $R1
-    Exch $R0
- 
-FunctionEnd
-
 ;--------------------------------------------------------
 ; Installer functions
 ;--------------------------------------------------------
@@ -461,9 +429,7 @@ Function .onInit
   Abort
 
   uninst:
-    push $R0
-    Call GetPath
-    pop $INSTDIR
+    ${GetParent} $R0 $INSTDIR
 	
     ClearErrors
     ; Run uninstaller from installed directory

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -377,6 +377,38 @@ Function DetectVSAndSDK
     ClearErrors
 FunctionEnd
 
+; Get path component of file name
+ ; Usage:
+ ;   Push "C:\Program Files\Directory\Whatever"
+ ;   Call GetPath
+ ;   Pop $R0
+Function GetPath
+ 
+  Exch $R0
+  Push $R1
+  Push $R2
+  Push $R3
+ 
+  StrCpy $R1 0
+  StrLen $R2 $R0
+ 
+  loop:
+    IntOp $R1 $R1 + 1
+    IntCmp $R1 $R2 get 0 get
+    StrCpy $R3 $R0 1 -$R1
+    StrCmp $R3 "\" get
+  Goto loop
+ 
+  get:
+    StrCpy $R0 $R0 -$R1
+ 
+    Pop $R3
+    Pop $R2
+    Pop $R1
+    Exch $R0
+ 
+FunctionEnd
+
 ;--------------------------------------------------------
 ; Installer functions
 ;--------------------------------------------------------
@@ -429,6 +461,10 @@ Function .onInit
   Abort
 
   uninst:
+    push $R0
+    Call GetPath
+    pop $INSTDIR
+	
     ClearErrors
     ; Run uninstaller from installed directory
     ExecWait '$R0 /IC False _?=$INSTDIR' $K


### PR DESCRIPTION
this bug always makes me nervous because I usually use a changed folder and the uninstaller shows the default one. 
https://issues.dlang.org/show_bug.cgi?id=13234

also reuses old installation path from uninstall folder as default, reported in
https://issues.dlang.org/show_bug.cgi?id=12276