### PR TITLE
Update libcurl-7.44.0 - fix 15066

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -423,7 +423,7 @@ int main(string[] args)
 
     enum optlink = "optlink.zip";
     enum libC = "snn.lib";
-    enum libCurl = "libcurl-7.43.0-WinSSL-zlib-x86-x64.zip";
+    enum libCurl = "libcurl-7.44.0-WinSSL-zlib-x86-x64.zip";
 
     fetchFile("http://ftp.digitalmars.com/"~oldDMD, cacheDir~"/"~oldDMD);
     fetchFile("http://ftp.digitalmars.com/"~optlink, cacheDir~"/"~optlink);


### PR DESCRIPTION
http://d.darktech.org/libcurl-7.44.0-WinSSL-zlib-x86-x64.zip
MD5: 1f550d0485dc156e87628db49f4896e3

Please upload it to http://downloads.dlang.org/other/

This libcurl.dll has been compiled with -DENABLE_IPV6
Fix https://issues.dlang.org/show_bug.cgi?id=15066
