### PR TITLE
use xz compression for .deb/.rpm packages

### DIFF
--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -407,7 +407,7 @@ else
 
 	# create deb package
 	cd ..
-	fakeroot dpkg-deb -b $DMDDIR
+	fakeroot dpkg-deb -b -Zxz -z9 $DMDDIR
 
 
 	# disable pushd

--- a/linux/dmd_rpm.sh
+++ b/linux/dmd_rpm.sh
@@ -340,7 +340,7 @@ do
 		echo "%define _rpmdir $RPMDIR" >> dmd.spec
 
 		# create rpm file
-		fakeroot rpmbuild --quiet --buildroot=$TEMPDIR/$DMDDIR -bb --target $ARCH dmd.spec
+		fakeroot rpmbuild --quiet --buildroot=$TEMPDIR/$DMDDIR -bb --target $ARCH --define '_binary_payload w9.xzdio' dmd.spec
 
 
 		# disable pushd


### PR DESCRIPTION
- supported since many years
- binaries will be much smaller (about 50%)