### PR TITLE
Update libcurl-7.45.0

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -423,7 +423,7 @@ int main(string[] args)
 
     enum optlink = "optlink.zip";
     enum libC = "snn.lib";
-    enum libCurl = "libcurl-7.44.0-WinSSL-zlib-x86-x64.zip";
+    enum libCurl = "libcurl-7.45.0-WinSSL-zlib-x86-x64.zip";
 
     fetchFile("http://ftp.digitalmars.com/"~oldDMD, cacheDir~"/"~oldDMD);
     fetchFile("http://ftp.digitalmars.com/"~optlink, cacheDir~"/"~optlink);


### PR DESCRIPTION
http://d.darktech.org/libcurl-7.45.0-WinSSL-zlib-x86-x64.zip
MD5: 7dcf144a5174d6e4048cd17ec88376cb

Please upload it to http://downloads.dlang.org/other/

This package contains lib32mscoff\curl.lib