### PR TITLE
fix Issue 15284 - dmd installer hangs...

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -473,7 +473,7 @@ Function .onInit
 
   uninst:
     ${GetParent} $R0 $INSTDIR
-	
+
     ClearErrors
     ; Run uninstaller from installed directory
     ExecWait '$R0 /IC False _?=$INSTDIR' $K
@@ -486,7 +486,7 @@ Function .onInit
     StrCmp $K 0 +2
       Abort
     ; Remove in background the remaining uninstaller program itself
-    ExecWait '$R0 /IC False /S'
+    Exec '$R0 /IC False /S'
 
   done_uninst:
 


### PR DESCRIPTION
- ExecWait seems to loop infinitely for some people
  and it doesn't wait for the uninstaller anyhow
  http://nsis.sourceforge.net/When_I_use_ExecWait_uninstaller.exe_it_doesn't_wait_for_the_uninstaller