### PR TITLE
fix Issue 15284 - dmd installer hangs when updating installed windows version 

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -413,10 +413,12 @@ Function DetectVSAndSDK
     !insertmacro _DetectSDK "Microsoft SDKs\Windows\v7.0A" "InstallationFolder" "Lib\x64"
     IfErrors 0 done_sdk
     !insertmacro _DetectSDK "Microsoft SDKs\Windows\v6.0A" "InstallationFolder" "Lib\x64"
-    IfErrors done done_sdk
+    IfErrors no_sdk done_sdk
 
     done_sdk:
     StrCpy $WinSDKPath $0
+
+    no_sdk:
 
 FunctionEnd
 


### PR DESCRIPTION
there is an infinite loop when no SDK is detected

https://issues.dlang.org/show_bug.cgi?id=15284