### PR TITLE
installer script

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -4,6 +4,7 @@
 # License: Boost License 1.0 (www.boost.org/LICENSE_1_0.txt)
 # Authors: Martin Nowak
 
+_() {
 set -ueo pipefail
 
 # ------------------------------------------------------------------------------
@@ -512,3 +513,6 @@ install_dub() {
 parse_args "$@"
 resolve_latest $compiler
 run_command ${command:-install} $compiler
+}
+
+_ "$@"

--- a/script/install.sh
+++ b/script/install.sh
@@ -66,13 +66,15 @@ check_tools() {
 
 # ------------------------------------------------------------------------------
 
+mkdir -p "$path"
+TMP_ROOT=$(mktemp -d "$path/.installer_tmp_XXXXXX")
+
 mkdtemp() {
-    mkdir -p "$path/.installer_tmp"
-    mktemp -d "$path/.installer_tmp/XXXXXX"
+    mktemp -d "$TMP_ROOT/XXXXXX"
 }
 
 cleanup() {
-    rm -rf "$path/.installer_tmp";
+    rm -rf "$TMP_ROOT";
 }
 trap cleanup EXIT
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -105,6 +105,8 @@ command_help() {
 
   dmd|gdc|ldc           latest version of a compiler
   dmd|gdc|ldc-<version> specific version of a compiler (e.g. dmd-2.069.0, ldc-0.16.1-beta2)
+  dmd-nightly           latest dmd nightly
+  dmd-2015-11-22        specific dmd nightly
 '
 
     case $1 in
@@ -281,6 +283,11 @@ resolve_latest() {
             logV "Determing latest dmd version ($url)."
             compiler="dmd-$(curl -sS $url)"
             ;;
+        dmd-nightly)
+            local url=https://builds.dawg.eu/LATEST_NIGHTLY
+            logV "Determing latest dmd-nightly version ($url)."
+            compiler="dmd-$(curl -sS $url)"
+            ;;
         ldc)
             local url=https://ldc-developers.github.io/LATEST
             logV "Determing latest ldc version ($url)."
@@ -319,6 +326,16 @@ install_compiler() {
         else
             local url="http://downloads.dlang.org/releases/2.x/$ver/$basename.$arch"
         fi
+
+        download_and_unpack "$url" "$path/$1" "$url.sig"
+
+    # dmd-2015-11-20
+    elif [[ $1 =~ ^dmd-[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+        local basename="dmd.master.$os"
+        if [ $os = freebsd ]; then
+            basename="$basename-$model"
+        fi
+        local url="https://builds.dawg.eu/$1/$basename.tar.xz"
 
         download_and_unpack "$url" "$path/$1" "$url.sig"
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,0 +1,514 @@
+#!/usr/bin/env bash
+#
+# Copyright: Copyright 2015 Martin Nowak.
+# License: Boost License 1.0 (www.boost.org/LICENSE_1_0.txt)
+# Authors: Martin Nowak
+
+set -ueo pipefail
+
+# ------------------------------------------------------------------------------
+
+log() {
+    echo "${@//$HOME/\~}"
+}
+
+logV() {
+    if [ ! -z "$verbose" ]; then
+        log "$@";
+    fi
+}
+
+logE() {
+    log "$@" >&2
+}
+
+fatal() {
+    logE "$@"
+    exit 1
+}
+
+curl() {
+    : ${curl_user_agent:="installer/install.sh $(command curl --version | head -n 1)"}
+    command curl -f#L --retry 3 -A "${curl_user_agent}" "$@"
+}
+
+# ------------------------------------------------------------------------------
+
+command=
+compiler=
+verbose=
+path=~/dlang
+case $(uname -s) in
+    Darwin) os=osx;;
+    Linux) os=linux;;
+    FreeBSD) os=freebsd;;
+    *)
+        fatal "Unsupported OS $(uname -s)"
+        ;;
+esac
+case $(uname -m) in
+    x86_64|amd64) arch=x86_64; model=64;;
+    i*86) arch=x86; model=32;;
+    *)
+        fatal "Unsupported Arch $(uname -m)"
+        ;;
+esac
+
+check_tools() {
+    while [[ $# > 0 ]]; do
+        if ! command -v $1 &>/dev/null; then
+            fatal "Required tool $1 not found, please install it."
+        fi
+        shift
+    done
+}
+
+# ------------------------------------------------------------------------------
+
+mkdtemp() {
+    mkdir -p "$path/.installer_tmp"
+    mktemp -d "$path/.installer_tmp/XXXXXX"
+}
+
+cleanup() {
+    rm -rf "$path/.installer_tmp";
+}
+trap cleanup EXIT
+
+# ------------------------------------------------------------------------------
+
+usage() {
+    log 'Usage
+
+  install.sh [<command>] [<args>]
+
+Commands
+
+  install       Install a D compiler (default command)
+  uninstall     Remove an installed D compiler
+  list          List all installed D compilers
+  update        Update this dlang script
+
+Options
+
+  -h --help     Show this help
+  -p --path     Install location (default ~/dlang)
+  -v --verbose  Verbose output
+
+Run "install.sh <command> --help to get help for a specific command.
+'
+}
+
+command_help() {
+    local _compiler='Compiler
+
+  dmd|gdc|ldc           latest version of a compiler
+  dmd|gdc|ldc-<version> specific version of a compiler (e.g. dmd-2.069.0, ldc-0.16.1-beta2)
+'
+
+    case $1 in
+        install)
+            log 'Usage
+
+  install.sh install <compiler>
+
+Description
+
+  Download and install a D compiler.
+
+Examples
+
+  install.sh install dmd
+  install.sh dmd
+  install.sh install dmd-2.069.0
+  install.sh install ldc-0.16.1
+'
+            log "$_compiler"
+            ;;
+
+        uninstall)
+            log 'Usage
+
+  install.sh uninstall <compiler>
+
+Description
+
+  Uninstall a D compiler.
+
+Examples
+
+  install.sh uninstall dmd
+  install.sh uninstall dmd-2.069.0
+  install.sh uninstall ldc-0.16.1
+'
+            log "$_compiler"
+            ;;
+
+        list)
+            log 'Usage
+
+  install.sh list
+
+Description
+
+  List all installed D compilers.
+'
+            ;;
+
+        update)
+            log 'Usage
+
+  install.sh update
+
+Description
+
+  Update the dlang installer itself.
+'
+    esac
+}
+
+# ------------------------------------------------------------------------------
+
+parse_args() {
+    local _help=
+
+    while [[ $# > 0 ]]; do
+        case "$1" in
+            -h | --help)
+                _help=1
+                ;;
+
+            -p | --path)
+                if [ -z "${2:-}" ]; then
+                    fatal '-p|--path must be followed by a path.';
+                fi
+                path="$2"
+                ;;
+
+            -v | --verbose)
+                verbose=1
+                ;;
+
+            use | install | uninstall | list | update)
+                command=$1
+                ;;
+
+            remove)
+                command=uninstall
+                ;;
+
+            dmd | dmd-* | gdc | gdc-* | ldc | ldc-*)
+                compiler=$1
+                ;;
+        esac
+        shift
+    done
+
+    if [ -n "$_help" ]; then
+        [ -z "$command" ] && usage || command_help $command
+        exit 0
+    fi
+}
+
+# ------------------------------------------------------------------------------
+
+# run_command command [compiler]
+run_command() {
+    case $1 in
+        install)
+            check_tools curl
+            if [ ! -f "$path/install.sh" ]; then
+                install_dlang_installer
+            fi
+            if [ -z "${2:-}" ]; then
+                fatal "Missing compiler argument for $1 command.";
+            fi
+            if [ -d "$path/$2" ]; then
+                log "$2 already installed";
+            else
+                install_compiler $2
+            fi
+            install_dub
+            write_env_vars $2
+
+            if [ $(basename $SHELL) = fish ]; then
+                local suffix=.fish
+            fi
+            log "
+Run \`source $path/$2/activate${suffix:-}\` in your shell to use $2.
+This will setup PATH, LIBRARY_PATH, LD_LIBRARY_PATH, DMD, DC, and PS1 accordingly.
+Run \`deactivate\` later on to restore your environment."
+            ;;
+
+        uninstall)
+            if [ -z "${2:-}" ]; then
+                fatal "Missing compiler argument for $1 command.";
+            fi
+            uninstall_compiler $2
+            ;;
+
+        list)
+            if [ -n "${2:-}" ]; then
+                log "Ignoring compiler argument '$2' for list command.";
+            fi
+            list_compilers
+            ;;
+
+        update)
+            install_dlang_installer
+            ;;
+    esac
+}
+
+install_dlang_installer() {
+    mkdir -p "$path"
+    #local url=http://dlang.org/install.sh
+    local url=https://raw.githubusercontent.com/MartinNowak/installer/install_script/script/install.sh
+    logV "Downloading $url"
+    curl -sS "$url" -o "$path/install.sh"
+    chmod +x "$path/install.sh"
+    log "The latest version of this script was installed as $path/install.sh.
+It can be used it to install further D compilers.
+Run \`$path/install.sh --help\` for usage information.
+"
+}
+
+resolve_latest() {
+    case $compiler in
+        dmd)
+            local url=http://ftp.digitalmars.com/LATEST
+            logV "Determing latest dmd version ($url)."
+            compiler="dmd-$(curl -sS $url)"
+            ;;
+        ldc)
+            local url=https://ldc-developers.github.io/LATEST
+            logV "Determing latest ldc version ($url)."
+            compiler="ldc-$(curl -sS $url)"
+            ;;
+        gdc)
+            local url=http://gdcproject.org/downloads/LATEST
+            logV "Determing latest gdc version ($url)."
+            compiler="gdc-$(curl -sS $url)"
+            ;;
+    esac
+}
+
+install_compiler() {
+    local tmp=$(mkdtemp)
+
+    # dmd-2.065, dmd-2.068.0, dmd-2.068.1-b1
+    if [[ $1 =~ ^dmd-2\.([0-9]{3})(\.[0-9])?(-.*)?$ ]]; then
+        local basename="dmd.2.${BASH_REMATCH[1]}${BASH_REMATCH[2]}${BASH_REMATCH[3]}"
+        local ver="2.${BASH_REMATCH[1]}"
+
+        if [[ $ver > "2.064z" ]]; then
+            basename="$basename.$os"
+            ver="$ver${BASH_REMATCH[2]}"
+            if [ $os = freebsd ]; then
+                basename="$basename-$model"
+            fi
+        fi
+
+        if [[ $ver > "2.068.0z" ]]; then
+            local arch="tar.xz"
+        else
+            local arch="zip"
+        fi
+
+        if [ -n "${BASH_REMATCH[3]}" ]; then # pre-release
+            local url="http://downloads.dlang.org/pre-releases/2.x/$ver/$basename.$arch"
+        else
+            local url="http://downloads.dlang.org/releases/2.x/$ver/$basename.$arch"
+        fi
+
+        if [[ $url =~ \.tar\.xz$ ]]; then
+            check_tools tar xz
+            log "Downloading and unpacking $url"
+            curl "$url" | tar -C "$tmp" -Jxf -
+        else
+            check_tools unzip
+            log "Downloading $url"
+            curl "$url" -o "$tmp/dmd.zip"
+            log "Unpacking"
+            unzip -q -d "$tmp" "$tmp/dmd.zip"
+            rm "$tmp/dmd.zip"
+        fi
+        mv "$tmp" "$path/$1"
+
+    # ldc-0.12.1 or ldc-0.15.0-alpha1
+    elif [[ $1 =~ ^ldc-([0-9]+\.[0-9]+\.[0-9]+(-.*)?)$ ]]; then
+        local ver=${BASH_REMATCH[1]}
+        local url="https://github.com/ldc-developers/ldc/releases/download/v$ver/ldc2-$ver-$os-$arch.tar.xz"
+        if [ $os != linux ] && [ $os != osx ]; then
+            fatal "no ldc binaries available for $os"
+        fi
+
+        check_tools tar xz
+        log "Downloading and unpacking $url"
+        curl "$url" | tar --strip-components=1 -C "$tmp" -Jxf -
+        mv "$tmp" "$path/$1"
+
+    # gdc-4.8.2, gdc-4.9.0-alpha1, gdc-5.2, or gdc-5.2-alpha1
+    elif [[ $1 =~ ^gdc-([0-9]+\.[0-9]+(\.[0-9]+)?(-.*)?)$ ]]; then
+        local name=${BASH_REMATCH[0]}
+        if [ $os != linux ]; then
+            fatal "no gdc binaries available for $os"
+        fi
+        case $arch in
+            x86_64) local triplet=x86_64-linux-gnu;;
+            x86) local triplet=i686-linux-gnu;;
+        esac
+        local url="http://gdcproject.org/downloads/binaries/$triplet/$name.tar.xz"
+
+        check_tools tar xz
+        log "Downloading and unpacking $url"
+        curl "$url" | tar --strip-components=1 -C "$tmp" -Jxf -
+        url=https://raw.githubusercontent.com/D-Programming-GDC/GDMD/master/dmd-script
+        log "Downloading '$url'."
+        curl "$url" -o "$tmp/bin/gdmd"
+        chmod +x "$tmp/bin/gdmd"
+        mv "$tmp" "$path/$1"
+
+    else
+        rmdir "$tmp"
+        fatal "Unknown compiler '$1'"
+    fi
+}
+
+write_env_vars() {
+    case $1 in
+        dmd*)
+            [ $os = osx ] && local suffix= || local suffix=$model
+            local binpath=dmd2/$os/bin$suffix
+            local libpath=dmd2/$os/lib$suffix
+            local dc=dmd
+            local dmd=dmd
+            ;;
+
+        ldc*)
+            local binpath=bin
+            local libpath=lib
+            local dc=ldc2
+            local dmd=ldmd2
+            ;;
+
+        gdc*)
+            local binpath=bin
+            local libpath=lib;
+            local dc=gdc
+            local dmd=gdmd
+            ;;
+    esac
+
+    logV "Writing environment variables to $path/$1/activate"
+    cat > "$path/$1/activate" <<EOF
+deactivate() {
+    export PATH="\$_OLD_D_PATH"
+    export LIBRARY_PATH="\$_OLD_D_LIBRARY_PATH"
+    export LD_LIBRARY_PATH="\$_OLD_D_LD_LIBRARY_PATH"
+    export PS1="\$_OLD_D_PS1"
+
+    unset _OLD_D_PATH
+    unset _OLD_D_LIBRARY_PATH
+    unset _OLD_D_LD_LIBRARY_PATH
+    unset _OLD_D_PS1
+    unset DMD
+    unset DC
+    unset -f deactivate
+}
+
+_OLD_D_PATH="\$PATH"
+_OLD_D_LIBRARY_PATH="\$LIBRARY_PATH"
+_OLD_D_LD_LIBRARY_PATH="\$LD_LIBRARY_PATH"
+_OLD_D_PS1="\$PS1"
+
+export PATH="$path/dub:$path/$1/$binpath:\$PATH"
+export LIBRARY_PATH="$path/$1/$libpath:\$LIBRARY_PATH"
+export LD_LIBRARY_PATH="$path/$1/$libpath:\$LD_LIBRARY_PATH"
+export DMD=$dmd
+export DC=$dc
+export PS1="($1)\$PS1"
+EOF
+
+    logV "Writing environment variables to $path/$1/activate.fish"
+    cat > "$path/$1/activate.fish" <<EOF
+function deactivate
+    set -gx PATH \$_OLD_D_PATH
+    set -gx LIBRARY_PATH \$_OLD_D_LIBRARY_PATH
+    set -gx LD_LIBRARY_PATH \$_OLD_D_LD_LIBRARY_PATH
+
+    functions -e fish_prompt
+    functions -c _old_d_fish_prompt fish_prompt
+    functions -e _old_d_fish_prompt
+
+    set -e _OLD_D_PATH
+    set -e _OLD_D_LIBRARY_PATH
+    set -e _OLD_D_LD_LIBRARY_PATH
+    set -e DMD
+    set -e DC
+    functions -e deactivate
+end
+
+set -g _OLD_D_PATH \$PATH
+set -g _OLD_D_LIBRARY_PATH \$LIBRARY_PATH
+set -g _OLD_D_LD_LIBRARY_PATH \$LD_LIBRARY_PATH
+set -g _OLD_D_PS1 \$PS1
+
+set -gx PATH "$path/dub" "$path/$1/$binpath" \$PATH
+set -gx LIBRARY_PATH "$path/$1/$libpath" \$LIBRARY_PATH
+set -gx LD_LIBRARY_PATH "$path/$1/$libpath" \$LD_LIBRARY_PATH
+set -gx DMD $dmd
+set -gx DC $dc
+functions -c fish_prompt _old_d_fish_prompt
+function fish_prompt
+    printf '($1)'
+    _old_d_fish_prompt
+end
+EOF
+}
+
+uninstall_compiler() {
+    if [ ! -d "$path/$1" ]; then
+        fatal "$1 is not installed in $path"
+    fi
+    log "Removing $path/$1"
+    rm -rf "$path/$1"
+}
+
+list_compilers() {
+    check_tools egrep
+    if [ -d "$path" ]; then
+        ls "$path" | egrep -v '^dub|^install\.sh|^d-keyring\.gpg'
+    fi
+}
+
+install_dub() {
+    if [ $os != linux ] && [ $os != osx ]; then
+        log "no dub binaries available for $os"
+        return
+    fi
+    local url=http://code.dlang.org/download/LATEST
+    logV "Determing latest dub version ($url)."
+    dub="dub-$(curl -sS $url)"
+    if [ -d "$path/$dub" ]; then
+        log "$dub already installed"
+        return
+    fi
+    local tmp=$(mkdtemp)
+    local url="http://code.dlang.org/files/$dub-$os-$arch.tar.gz"
+
+    log "Downloading and unpacking $url"
+    curl "$url" | tar -C "$tmp" -zxf -
+    logV "Removing old dub versions"
+    rm -rf "$path/dub" "$path/dub-*"
+    mv "$tmp" "$path/$dub"
+    logV "Linking $path/dub -> $path/$dub"
+    ln -s $dub "$path/dub"
+}
+
+# ------------------------------------------------------------------------------
+
+[ $# -eq 0 ] && usage && exit 1
+parse_args "$@"
+resolve_latest $compiler
+run_command ${command:-install} $compiler

--- a/script/install.sh
+++ b/script/install.sh
@@ -420,7 +420,7 @@ verify() {
         return
     fi
     if [ ! -f "$path/d-keyring.gpg" ]; then
-        curl -sS http://dlang.org/d-keyring.gpg -o "$path/d-keyring.gpg"
+        curl -sS https://dlang.org/d-keyring.gpg -o "$path/d-keyring.gpg"
     fi
     if ! $GPG -q --verify --keyring "$path/d-keyring.gpg" --no-default-keyring <(curl -sS "$1") "$2" 2>/dev/null; then
         fatal "Invalid signature $1"

--- a/script/install.sh
+++ b/script/install.sh
@@ -267,8 +267,7 @@ Run \`deactivate\` later on to restore your environment."
 
 install_dlang_installer() {
     mkdir -p "$path"
-    #local url=http://dlang.org/install.sh
-    local url=https://raw.githubusercontent.com/MartinNowak/installer/install_script/script/install.sh
+    local url=https://dlang.org/install.sh
     logV "Downloading $url"
     curl -sS "$url" -o "$path/install.sh"
     chmod +x "$path/install.sh"


### PR DESCRIPTION
- installs requested dmd/gdc/ldc versions
  and dub to a user-wide path (~/dlang) and
  writes sourceable files to activate them
- installs itself to ~/dlang/install.sh
  and can later be used to install/uninstall/list
  compilers or update the script itself
- writes no file outside of the root path, so
  a simple `rm -rf ~/dlang` removes everything
- only requires bash, curl, and xz