### PR TITLE
modify access rights for sc.ini to allow all users to read the file

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -309,6 +309,10 @@ SectionGroup /e "D2"
     no_ucrt_detected:
       ClearErrors
 
+    ; Make sc.ini read accessible by all users
+    AccessControl::GrantOnFile "$INSTDIR\dmd2\windows\bin\sc.ini" "(BU)" "GenericRead"
+    Pop $0 ; ignore error
+
   SectionEnd
 
 


### PR DESCRIPTION
The permission is lost during modification by _ReplaceInFile.

You'll need to install the AccessControl-plugin for NSIS to build this.